### PR TITLE
Add checks for null payload

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    client_success (0.1.0)
+    client_success (0.1.1)
       activesupport (~> 5.2)
       dry-types (= 0.11.0)
       faraday
@@ -46,10 +46,10 @@ GEM
       ffi (>= 1.3.0)
     faker (2.10.2)
       i18n (>= 1.6, < 2)
-    faraday (1.0.0)
+    faraday (0.17.0)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (1.0.0.rc1)
-      faraday (~> 1.0)
+    faraday_middleware (0.14.0)
+      faraday (>= 0.7.4, < 1.0)
     ffi (1.12.2)
     hashie (4.1.0)
     i18n (1.8.2)
@@ -108,4 +108,4 @@ DEPENDENCIES
   vcr
 
 BUNDLED WITH
-   2.0.1
+   2.1.4

--- a/lib/client_success/contact.rb
+++ b/lib/client_success/contact.rb
@@ -82,10 +82,10 @@ module ClientSuccess
       response = connection.get(
         "/v1/contacts?#{params.compact.to_query}")
 
-      payload = response.body
-
-      DomainModel::Contact.new(
-        payload.deep_transform_keys(&:underscore))
+      if response && response.body
+        payload = response.body
+        DomainModel::Contact.new(payload.deep_transform_keys(&:underscore))
+      end
     rescue Connection::ParsingError
       nil
     end

--- a/lib/client_success/version.rb
+++ b/lib/client_success/version.rb
@@ -1,3 +1,3 @@
 module ClientSuccess
-  VERSION = "0.1.0".freeze
+  VERSION = "0.1.1".freeze
 end

--- a/spec/client_success/contact_spec.rb
+++ b/spec/client_success/contact_spec.rb
@@ -69,5 +69,72 @@ module ClientSuccess
           "contact_state"       => "Arizona")
       end
     end
+
+    describe "#get_details_by_client_external_id_and_email" do
+      let(:client_external_id) { "5372a2ad-7e14-4ea4-a20a-c7a717f9a845" }
+      let(:email) { "skuunk+clien@gmail.com" }
+
+      around(:each) do |example|
+        VCR.use_cassette("client_success/contact/get_details_by_client_external_id_and_email") do
+          example.run
+        end
+      end
+
+      context "when it gets the results" do
+        it "gets the details" do
+          contact = service.get_details_by_client_external_id_and_email(
+            client_external_id: client_external_id,
+            email: email,
+            connection: connection)
+
+          expect(contact).to eq(
+            "id" => 12182818,
+            "uuid" => "cnt_pzda6yfp",
+            "client_id" => 90764325,
+            "status_id" => 1,
+            "email" => "skuunk+clien@gmail.com",
+            "phone" => nil,
+            "mobile" => nil,
+            "title" => nil,
+            "linkedin_url" => nil,
+            "first_name" => "Jimmy",
+            "last_name" => "Neutron",
+            "note" => nil,
+            "executive_sponsor" => true,
+            "advocate" => false,
+            "champion" => false,
+            "starred" => false,
+            "key_contact" => false,
+            "street" => nil,
+            "city" => nil,
+            "zip" => nil,
+            "country" => nil,
+            "timezone" => nil,
+            "salesforce_id" => nil,
+            "external_id" => nil,
+            "client" => "LOOKFORMETONY",
+            "last_engagement" => nil,
+            "engagement_count" => 0,
+            "usage_id" => nil,
+            "custom_field_values" => [],
+            "name" => "Jimmy Neutron",
+            "preferred_name" => nil,
+            "photo_url" => nil,
+            "contact_state" => nil)
+        end
+      end
+
+      context "when payload is nil" do
+        it "returns nil" do
+          expect(connection).to receive(:get).and_return(nil)
+          contact = service.get_details_by_client_external_id_and_email(
+            client_external_id: client_external_id,
+            email: email,
+            connection: connection)
+          expect(contact).to be_nil
+        end
+      end
+
+    end
   end
 end

--- a/spec/vcr_cassettes/client_success/contact/get_details_by_client_external_id_and_email.yml
+++ b/spec/vcr_cassettes/client_success/contact/get_details_by_client_external_id_and_email.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.clientsuccess.com/v1/contacts?clientExternalId=5372a2ad-7e14-4ea4-a20a-c7a717f9a845&email=skuunk%2Bclien%40gmail.com
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.0
+      Authorization:
+      - 4ceb5a35-c4aa-48c2-9a10-dc0156f83281
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx
+      date:
+      - Tue, 03 Mar 2020 01:07:46 GMT
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      x-content-type-options:
+      - nosniff
+      x-xss-protection:
+      - 1; mode=block
+      cache-control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      pragma:
+      - no-cache
+      expires:
+      - '0'
+      x-frame-options:
+      - DENY
+      access-control-allow-methods:
+      - GET, POST, PUT, DELETE, OPTIONS, PATCH
+      access-control-max-age:
+      - '1800'
+      x-application-context:
+      - application
+      x-cs-tenant-id:
+      - '405'
+      x-cs-user-id:
+      - '5082'
+      x-newrelic-app-data:
+      - PxQBVlVTCwcTUllaAggPUUYdFGQHBDcQUQxLA1tMXV1dORYyQRNaDAN1WA8SEVdfXAETPhhQRw84HlVcDBICAUQRGEp/fWAbEUkJTwFNA0xUBQdWV1QJAANITFMbEwIEBlUPC1dfAgEGWgFRDAAWHlUEVRJUPA==
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload, max-age=31536000; includeSubDomains;
+        preload
+      access-control-allow-origin:
+      - "*"
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":12182818,"uuid":"cnt_pzda6yfp","clientId":90764325,"statusId":1,"email":"skuunk+clien@gmail.com","phone":null,"mobile":null,"title":null,"linkedinUrl":null,"firstName":"Jimmy","lastName":"Neutron","note":null,"executiveSponsor":true,"advocate":false,"champion":false,"starred":false,"keyContact":false,"street":null,"city":null,"zip":null,"country":null,"timezone":null,"salesforceId":null,"externalId":null,"client":"LOOKFORMETONY","lastEngagement":null,"engagementCount":0,"usageId":null,"customFieldValues":[],"name":"Jimmy
+        Neutron","preferredName":null,"photoUrl":null,"contactState":null}'
+    http_version:
+  recorded_at: Tue, 03 Mar 2020 01:07:46 GMT
+recorded_with: VCR 5.0.0


### PR DESCRIPTION
We got errors running the contact sync task

```2020-03-04T00:00:24.741592+00:00 app[advanced-scheduler.8526]: Progress: |rake aborted!
2020-03-04T00:00:24.741803+00:00 app[advanced-scheduler.8526]: NoMethodError: undefined method `deep_transform_keys' for nil:NilClass
2020-03-04T00:00:24.741908+00:00 app[advanced-scheduler.8526]: /app/vendor/bundle/ruby/2.6.0/bundler/gems/client_success-afb4e6c7e0a8/lib/client_success/contact.rb:88:in `get_details_by_client_external_id_and_email'
2020-03-04T00:00:24.741931+00:00 app[advanced-scheduler.8526]: /app/lib/integration/contact.rb:14:in `update_or_create'
```

I put in a check to make sure the response and payload were not null.