### PR TITLE
Remove nil response check

### DIFF
--- a/lib/client_success.rb
+++ b/lib/client_success.rb
@@ -1,5 +1,7 @@
-require "active_support"
-require "active_support/core_ext"
+require "active_support/core_ext/string/inflections"
+require "active_support/core_ext/hash/keys"
+require "active_support/core_ext/object/to_query"
+require "active_support/core_ext/object/blank"
 
 require "hashie"
 

--- a/lib/client_success.rb
+++ b/lib/client_success.rb
@@ -1,6 +1,5 @@
-require "active_support/core_ext/string/inflections"
-require "active_support/core_ext/hash/keys"
-require "active_support/core_ext/object/to_query"
+require "active_support"
+require "active_support/core_ext"
 
 require "hashie"
 

--- a/lib/client_success/contact.rb
+++ b/lib/client_success/contact.rb
@@ -82,7 +82,7 @@ module ClientSuccess
       response = connection.get(
         "/v1/contacts?#{params.compact.to_query}")
 
-      if response && response.body
+      if response.body
         payload = response.body
         DomainModel::Contact.new(payload.deep_transform_keys(&:underscore))
       end

--- a/lib/client_success/contact.rb
+++ b/lib/client_success/contact.rb
@@ -6,7 +6,8 @@ module ClientSuccess
   module Contact
     extend self
 
-    class NotFound < StandardError; end
+    class Error < StandardError; end
+    class NotFound < Error; end
 
     def list_all(client_id:, connection:)
       response = connection.get(
@@ -85,10 +86,10 @@ module ClientSuccess
         "/v1/contacts?#{params.compact.to_query}")
 
       # for some reason the ClientSuccess API does not return a 404
-      # but instead a body set to null if the contact is not found
+      # but instead a body containing the string "null" if the contact is not found
       # this is probably a security restriction on their end, but we will instead raise an error
 
-      if response.body.nil?
+      if response.body.blank?
         raise NotFound, "contact with email '#{email}' not found on client '#{client_external_id}'"
       else
         payload = response.body

--- a/lib/client_success/contact.rb
+++ b/lib/client_success/contact.rb
@@ -6,6 +6,8 @@ module ClientSuccess
   module Contact
     extend self
 
+    class NotFound < StandardError; end
+
     def list_all(client_id:, connection:)
       response = connection.get(
         "/v1/clients/#{client_id}/contacts")
@@ -82,12 +84,16 @@ module ClientSuccess
       response = connection.get(
         "/v1/contacts?#{params.compact.to_query}")
 
-      if response.body
+      # for some reason the ClientSuccess API does not return a 404
+      # but instead a body set to null if the contact is not found
+      # this is probably a security restriction on their end, but we will instead raise an error
+
+      if response.body.nil?
+        raise NotFound, "contact with email '#{email}' not found on client '#{client_external_id}'"
+      else
         payload = response.body
         DomainModel::Contact.new(payload.deep_transform_keys(&:underscore))
       end
-    rescue Connection::ParsingError
-      nil
     end
 
     def search(term:, connection:)

--- a/spec/client_success/contact_spec.rb
+++ b/spec/client_success/contact_spec.rb
@@ -126,7 +126,7 @@ module ClientSuccess
 
       context "when payload is nil" do
         it "returns nil" do
-          expect(connection).to receive(:get).and_return(nil)
+          expect(connection).to receive(:get).and_return(Faraday::Response.new())
           contact = service.get_details_by_client_external_id_and_email(
             client_external_id: client_external_id,
             email: email,

--- a/spec/client_success/contact_spec.rb
+++ b/spec/client_success/contact_spec.rb
@@ -80,7 +80,7 @@ module ClientSuccess
         end
       end
 
-      context "when it gets the results" do
+      context "when the contact is found" do
         it "gets the details" do
           contact = service.get_details_by_client_external_id_and_email(
             client_external_id: client_external_id,
@@ -124,17 +124,17 @@ module ClientSuccess
         end
       end
 
-      context "when payload is nil" do
-        it "returns nil" do
-          expect(connection).to receive(:get).and_return(Faraday::Response.new())
-          contact = service.get_details_by_client_external_id_and_email(
-            client_external_id: client_external_id,
-            email: email,
-            connection: connection)
-          expect(contact).to be_nil
+      context "when contact is not found" do
+        it "raises a not found error" do
+          expect(connection).to receive(:get).and_return(Faraday::Response.new)
+          expect do
+            contact = service.get_details_by_client_external_id_and_email(
+              client_external_id: client_external_id,
+              email: email,
+              connection: connection)
+          end.to raise_error(ClientSuccess::Contact::NotFound)
         end
       end
-
     end
   end
 end


### PR DESCRIPTION
Raise error if we get a nil for contact via `get_details_by_client_external_id_and_email`

Even though ClientSuccess gives us a 200 with null body.

We will need to update the connector when we update the gem there.