### PR TITLE
Need to deep transform the attributes on client.update to handle custom field values

### DIFF
--- a/lib/client_success/client.rb
+++ b/lib/client_success/client.rb
@@ -76,7 +76,7 @@ module ClientSuccess
     #       supply everything :)
     def update(client_id:, attributes:, connection:)
       body = attributes
-        .transform_keys { |k| k.to_s.camelize(:lower) }
+        .deep_transform_keys { |k| k.to_s.camelize(:lower) }
         .to_json
 
       response = connection.put(

--- a/spec/client_success/client_spec.rb
+++ b/spec/client_success/client_spec.rb
@@ -163,5 +163,17 @@ module ClientSuccess
           "assigned_csm"                   => nil)
       end
     end
+
+    describe "#update" do
+      let(:client_id) { "123" }
+      let(:attributes) { { first_name: "Tony", custom_field_values: [{ active_client_success_cycle_id: 1 }] } }
+      let(:response) { Faraday::Response.new() }
+
+      it "does a deep transform on the attributes" do
+        expect(connection).to receive(:put).with("/v1/clients/#{client_id}", "{\"firstName\":\"Tony\",\"customFieldValues\":[{\"activeClientSuccessCycleId\":1}]}").and_return(response)
+        allow(response).to receive(:body).and_return({"customFieldValues" => []})
+        service.update(client_id: client_id, attributes: attributes, connection: connection)
+      end
+    end
   end
 end


### PR DESCRIPTION
The reason we were having trouble sending back the custom field values in the update was because we were not transforming them back into camel case.

This should allow us to eventually send one API call to client update instead of having to do multiple ones for custom field values