### PR TITLE
Raise connection error in the gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    client_success (0.1.5)
+    client_success (0.1.6)
       activesupport (~> 5.2)
       dry-types (= 0.11.0)
       faraday
@@ -89,7 +89,7 @@ GEM
     thread_safe (0.3.6)
     typhoeus (1.3.1)
       ethon (>= 0.9.0)
-    tzinfo (1.2.6)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.1)
     vcr (5.1.0)

--- a/lib/client_success/connection.rb
+++ b/lib/client_success/connection.rb
@@ -10,6 +10,7 @@ module ClientSuccess
     class NotFound < Error; end
 
     class ParsingError < Error; end
+    class ConnectionError < Error; end
 
     class << self
       def authorised(access_token)
@@ -92,6 +93,8 @@ module ClientSuccess
       else
         raise Error, error
       end
+    rescue Faraday::ConnectionFailed => error
+      raise ConnectionError, error
     rescue SignalException => error
       raise Error, error
     end

--- a/lib/client_success/version.rb
+++ b/lib/client_success/version.rb
@@ -1,3 +1,3 @@
 module ClientSuccess
-  VERSION = "0.1.5".freeze
+  VERSION = "0.1.6".freeze
 end


### PR DESCRIPTION
There are a number of errors caused by Faraday::Connection failed so I thought I would raise it separately so we could handle it independently.