### PR TITLE
Rename Connection::ConnectionError to Connection::Failed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    client_success (0.1.6)
+    client_success (0.1.7)
       activesupport (~> 5.2)
       dry-types (= 0.11.0)
       faraday

--- a/lib/client_success/connection.rb
+++ b/lib/client_success/connection.rb
@@ -10,7 +10,7 @@ module ClientSuccess
     class NotFound < Error; end
 
     class ParsingError < Error; end
-    class ConnectionError < Error; end
+    class Failed < Error; end
 
     class << self
       def authorised(access_token)
@@ -94,7 +94,7 @@ module ClientSuccess
         raise Error, error
       end
     rescue Faraday::ConnectionFailed => error
-      raise ConnectionError, error
+      raise Failed, error
     rescue SignalException => error
       raise Error, error
     end

--- a/lib/client_success/version.rb
+++ b/lib/client_success/version.rb
@@ -1,3 +1,3 @@
 module ClientSuccess
-  VERSION = "0.1.6".freeze
+  VERSION = "0.1.7".freeze
 end


### PR DESCRIPTION
Make things less confusing