### PR TITLE
Add strip emoji function and apply it to client and contact

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    client_success (0.1.7)
+    client_success (0.1.8)
       activesupport (~> 5.2)
       dry-types (= 0.11.0)
       faraday

--- a/lib/client_success/client.rb
+++ b/lib/client_success/client.rb
@@ -55,6 +55,8 @@ module ClientSuccess
     end
 
     def create(attributes:, connection:)
+      attributes = connection.strip_emojis(attributes)
+
       body = Schema::Client::Create[attributes]
         .transform_keys { |k| k.to_s.camelize(:lower) }
         .to_json
@@ -75,6 +77,8 @@ module ClientSuccess
     #       i.e. any fields not supplied will be set to null - so make sure you
     #       supply everything :)
     def update(client_id:, attributes:, connection:)
+      attributes = connection.strip_emojis(attributes)
+
       body = attributes
         .deep_transform_keys { |k| k.to_s.camelize(:lower) }
         .to_json

--- a/lib/client_success/connection.rb
+++ b/lib/client_success/connection.rb
@@ -12,6 +12,9 @@ module ClientSuccess
     class ParsingError < Error; end
     class Failed < Error; end
 
+    # from https://stackoverflow.com/questions/24672834/how-do-i-remove-emoji-from-string
+    EMOJI_REGEX = /[\u{203C}\u{2049}\u{20E3}\u{2122}\u{2139}\u{2194}-\u{2199}\u{21A9}-\u{21AA}\u{231A}-\u{231B}\u{23E9}-\u{23EC}\u{23F0}\u{23F3}\u{24C2}\u{25AA}-\u{25AB}\u{25B6}\u{25C0}\u{25FB}-\u{25FE}\u{2600}-\u{2601}\u{260E}\u{2611}\u{2614}-\u{2615}\u{261D}\u{263A}\u{2648}-\u{2653}\u{2660}\u{2663}\u{2665}-\u{2666}\u{2668}\u{267B}\u{267F}\u{2693}\u{26A0}-\u{26A1}\u{26AA}-\u{26AB}\u{26BD}-\u{26BE}\u{26C4}-\u{26C5}\u{26CE}\u{26D4}\u{26EA}\u{26F2}-\u{26F3}\u{26F5}\u{26FA}\u{26FD}\u{2702}\u{2705}\u{2708}-\u{270C}\u{270F}\u{2712}\u{2714}\u{2716}\u{2728}\u{2733}-\u{2734}\u{2744}\u{2747}\u{274C}\u{274E}\u{2753}-\u{2755}\u{2757}\u{2764}\u{2795}-\u{2797}\u{27A1}\u{27B0}\u{2934}-\u{2935}\u{2B05}-\u{2B07}\u{2B1B}-\u{2B1C}\u{2B50}\u{2B55}\u{3030}\u{303D}\u{3297}\u{3299}\u{1F004}\u{1F0CF}\u{1F170}-\u{1F171}\u{1F17E}-\u{1F17F}\u{1F18E}\u{1F191}-\u{1F19A}\u{1F1E7}-\u{1F1EC}\u{1F1EE}-\u{1F1F0}\u{1F1F3}\u{1F1F5}\u{1F1F7}-\u{1F1FA}\u{1F201}-\u{1F202}\u{1F21A}\u{1F22F}\u{1F232}-\u{1F23A}\u{1F250}-\u{1F251}\u{1F300}-\u{1F320}\u{1F330}-\u{1F335}\u{1F337}-\u{1F37C}\u{1F380}-\u{1F393}\u{1F3A0}-\u{1F3C4}\u{1F3C6}-\u{1F3CA}\u{1F3E0}-\u{1F3F0}\u{1F400}-\u{1F43E}\u{1F440}\u{1F442}-\u{1F4F7}\u{1F4F9}-\u{1F4FC}\u{1F500}-\u{1F507}\u{1F509}-\u{1F53D}\u{1F550}-\u{1F567}\u{1F5FB}-\u{1F640}\u{1F645}-\u{1F64F}\u{1F680}-\u{1F68A}]/.freeze
+
     class << self
       def authorised(access_token)
         new.tap { |conn| conn.access_token = access_token }
@@ -59,6 +62,10 @@ module ClientSuccess
 
     def options(path, headers = {}, &block)
       raise NotImplementedError
+    end
+
+    def strip_emojis(attributes)
+      attributes.transform_values { |v| v.respond_to?(:gsub) ? v.gsub(EMOJI_REGEX, "") : v }
     end
 
     private

--- a/lib/client_success/contact.rb
+++ b/lib/client_success/contact.rb
@@ -40,6 +40,8 @@ module ClientSuccess
     end
 
     def create(client_id:, attributes:, connection:)
+      attributes = connection.strip_emojis(attributes)
+
       body = Schema::Contact::Create[attributes]
         .transform_keys { |k| k.to_s.camelize(:lower) }
         .to_json
@@ -54,6 +56,8 @@ module ClientSuccess
     end
 
     def update(id:, client_id:, attributes:, connection:)
+      attributes = connection.strip_emojis(attributes)
+
       body = Schema::Contact::Update[attributes]
         .transform_keys { |k| k.to_s.camelize(:lower) }
         .to_json

--- a/lib/client_success/version.rb
+++ b/lib/client_success/version.rb
@@ -1,3 +1,3 @@
 module ClientSuccess
-  VERSION = "0.1.7".freeze
+  VERSION = "0.1.8".freeze
 end

--- a/spec/client_success/client_spec.rb
+++ b/spec/client_success/client_spec.rb
@@ -162,6 +162,25 @@ module ClientSuccess
           "external_id"                    => "2474027099",
           "assigned_csm"                   => nil)
       end
+
+      context "with an emoji in the client name" do
+        let(:external_id) { "2474027099" }
+        let(:attributes) do
+          {
+            name:                           "💥Tony",
+            status_id:                      ::ClientSuccess::Status::TRIAL,
+            external_id:                    external_id
+          }
+        end
+        let(:response) { Faraday::Response.new }
+
+        it "strips the emoji from the client name" do
+          expect(connection).to receive(:post).with("/v1/clients", "{\"name\":\"Tony\",\"statusId\":#{::ClientSuccess::Status::TRIAL},\"externalId\":\"#{external_id}\"}").and_return(response)
+          allow(response).to receive(:body).and_return("customFieldValues" => [])
+
+          service.create(attributes: attributes, connection: connection)
+        end
+      end
     end
 
     describe "#update" do
@@ -173,6 +192,16 @@ module ClientSuccess
         expect(connection).to receive(:put).with("/v1/clients/#{client_id}", "{\"firstName\":\"Tony\",\"customFieldValues\":[{\"activeClientSuccessCycleId\":1}]}").and_return(response)
         allow(response).to receive(:body).and_return("customFieldValues" => [])
         service.update(client_id: client_id, attributes: attributes, connection: connection)
+      end
+
+      context "with an emoji in the client name" do
+        let(:attributes) { { first_name: "💥Tony", custom_field_values: [{ active_client_success_cycle_id: 1 }] } }
+
+        it "strips the emoji from the attributes" do
+          expect(connection).to receive(:put).with("/v1/clients/#{client_id}", "{\"firstName\":\"Tony\",\"customFieldValues\":[{\"activeClientSuccessCycleId\":1}]}").and_return(response)
+          allow(response).to receive(:body).and_return("customFieldValues" => [])
+          service.update(client_id: client_id, attributes: attributes, connection: connection)
+        end
       end
     end
   end

--- a/spec/client_success/connection_spec.rb
+++ b/spec/client_success/connection_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+module ClientSuccess
+  RSpec.describe(Connection) do
+    let(:access_token) { "124f4ab2-c951-4dd2-9519-5546eaa20bc6" }
+    let(:connection) { Connection.authorised(access_token) }
+
+    describe "#strip_emojis" do
+      let(:external_id) { "2474027099" }
+      let(:attributes) do
+        {
+          name:                           "💥Tony",
+          status_id:                      ::ClientSuccess::Status::TRIAL,
+          external_id:                    external_id
+        }
+      end
+
+      it "should strip the emoji from the attributes" do
+        expect(connection.strip_emojis(attributes)).to eq(external_id: "2474027099", name: "Tony", status_id: 3)
+      end
+    end
+  end
+end

--- a/spec/client_success/contact_spec.rb
+++ b/spec/client_success/contact_spec.rb
@@ -68,6 +68,49 @@ module ClientSuccess
           "name"                => "Carroll Altenwerth",
           "contact_state"       => "Arizona")
       end
+
+      context "with an emojis in the contact data" do
+        let(:client_id) { 90289610 }
+        let(:attributes) do
+          {
+            client_id:                            client_id,
+            first_name:                           "💥Tony",
+            last_name:                            "💥Smith",
+            email:                                "💥test@test.com💥"
+          }
+        end
+        let(:response) { Faraday::Response.new }
+
+        it "strips the emoji from the client name" do
+          expect(connection).to receive(:post).with("/v1/clients/90289610/contacts", "{\"email\":\"test@test.com\",\"firstName\":\"Tony\",\"lastName\":\"Smith\"}").and_return(response)
+          allow(response).to receive(:body).and_return("customFieldValues" => [])
+
+          service.create(client_id: client_id, attributes: attributes, connection: connection)
+        end
+      end
+    end
+
+    describe "#update" do
+      let(:contact_id) { "456" }
+      let(:client_id) { "123" }
+      let(:attributes) { { first_name: "Tony" } }
+      let(:response) { Faraday::Response.new }
+
+      it "does a deep transform on the attributes" do
+        expect(connection).to receive(:put).with("/v1/clients/#{client_id}/contacts/#{contact_id}/details", "{\"firstName\":\"Tony\"}").and_return(response)
+        allow(response).to receive(:body).and_return("customFieldValues" => [])
+        service.update(id: contact_id, client_id: client_id, attributes: attributes, connection: connection)
+      end
+
+      context "with an emoji in the client name" do
+        let(:attributes) { { first_name: "💥Tony", custom_field_values: [{ active_client_success_cycle_id: 1 }] } }
+
+        it "strips the emoji from the attributes" do
+          expect(connection).to receive(:put).with("/v1/clients/#{client_id}/contacts/#{contact_id}/details", "{\"firstName\":\"Tony\"}").and_return(response)
+          allow(response).to receive(:body).and_return("customFieldValues" => [])
+          service.update(id: contact_id, client_id: client_id, attributes: attributes, connection: connection)
+        end
+      end
     end
 
     describe "#get_details_by_client_external_id_and_email" do


### PR DESCRIPTION
https://ignitionapp.atlassian.net/browse/APP-4193

We had some issues with a client with emojis in the name. It was being rejected by Client Success which was stopping the sync.

I initially updated the connector, but the responsibility should really be on the gem.